### PR TITLE
Fixing NaN in "Loved by Community"

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -95,8 +95,10 @@ class App extends Component {
         currentCatIndexGlobal = index;
         this.setState({
             rawData: dataExtractor(index)
+        },
+        ()=>{
+            this.getData(this.state.rawData.langArray[0]);
         })
-        this.getData(this.state.rawData.langArray[0]);
     }
 
     render() {


### PR DESCRIPTION
The state was not set when the `getData` function fired so I'm passing the function as a second argument to `setSate`. Now the function will fire after the state is set and will use the new values of the category instead of the old ones.