### PR TITLE
updated eslint version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "not op_mini all"
   ],
   "devDependencies": {
-    "eslint": "^5.12.0",
+    "eslint": "^5.6.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^3.3.0",
     "eslint-plugin-import": "^2.14.0",


### PR DESCRIPTION
fixes npm start failure - updating eslint dev-dependency to 5.6

issue #27 