### PR TITLE
Fixing white space on footer strapline

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -14,7 +14,7 @@ const Footer = ({ contrib }) => (
             <a className="navbar-brand pb-3" href="/#">
               <img src={logo} alt="logo" height="50" />
             </a>
-            <p className="text-muted text-justify">
+            <p className="text-muted text-left">
               Dedicated to monitoring the top 5 job demands in the 5 categories: Web, Mobile,
               Programming Languages, Backend
             </p>


### PR DESCRIPTION
Changing the text align of footer strapline / paragraph to text-left as text justify was creating slightly large white spacing.