### PR TITLE
Added padding to fix zone number scale view

### DIFF
--- a/src/components/Data/SourceChart.js
+++ b/src/components/Data/SourceChart.js
@@ -46,6 +46,7 @@ const SourceChart = () => (
           bodyFontColor: '#000',
           bodyFontSize: 14,
           displayColors: false,
+          padding: 5,
         },
       }}
     />


### PR DESCRIPTION
Number '50' in chartjs-render-monitor was obscured. Adding padding to make it visible.