### PR TITLE
add padding top to data source img icons

### DIFF
--- a/src/components/Data/DataSource.css
+++ b/src/components/Data/DataSource.css
@@ -15,10 +15,11 @@
 }
 
 .zone > img {
+  padding-top: 1.25rem;
   width: 60px;
   height: auto;
   margin-bottom: 230px;
-  align-content: center
+  align-content: center;
 }
 
 .more {


### PR DESCRIPTION
I noticed align-content did not have proper css syntax, so added semi. also, padding top gives it just enough padding to make the data source icon centered, and I think it looks better.