### PR TITLE
adding margin-bottom to button-primary 1st child in hamburger nav

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -45,6 +45,9 @@
 
 @media only screen and (max-width: 991px) {
     #header {
-        background: #fff
+        background: #fff;
+    }
+    .button-primary:first-child {
+        margin-bottom: 7px;
     }
 }


### PR DESCRIPTION
Fixed issue: not enough space between buttons in nav, when screen is smaller than 992px - adding margin to first button