### PR TITLE
changes to icon sizes in how we collect data section

### DIFF
--- a/src/components/Data/DataSource.css
+++ b/src/components/Data/DataSource.css
@@ -66,14 +66,20 @@
     margin-bottom: 1rem !important;
 }
 
+@media only screen and (max-width: 620px){
+  .zone > img {
+    width: 80.500%;
+  }
+}
+
 @media only screen and (min-width: 620px) and (max-width: 760px){
     .zone > img {
-      width: 80.500%;
+      width: 75.500%;
   }
 }
 @media only screen and (min-width: 760px) and (max-width: 1110px){
   .zone > img {
-    width: 60.500%;
+    width: 50.500%;
 }
 }
 @media only screen and (min-width: 1110px){


### PR DESCRIPTION
I've changed the sizes for the icons in the How We Collect Our Data section.
It looks good in the laptop browser when I shrink the page. However, the images were overflowing the boxes on my mobile, but i couldn't replicate that on my laptop browser, so I'm unsure how this will actually look on a mobile device.