### PR TITLE
Better underline for titles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,7 +14,6 @@
     .trends {
         padding: 10px;
     }
-
     .ranked-langs {
         padding-bottom: 1rem !important;
     }
@@ -23,7 +22,6 @@
 /* Fonts and Imports */
 
 @import url('https://fonts.googleapis.com/css?family=Comfortaa|Exo+2|Raleway|Ubuntu');
-
 body {
     background-color: rgb(255, 255, 255);
     background-image: url("./images/parallax.svg");
@@ -32,7 +30,6 @@ body {
     background-repeat: no-repeat;
     background-size: cover;
 }
-
 
 body::-webkit-scrollbar {
     width: 15px;
@@ -100,7 +97,9 @@ body::-webkit-scrollbar-thumb {
 
 h2 {
     color: var(--one);
-    text-decoration: underline;
+    display: inline-flex;
+    border-bottom: 2px solid var(--one);
+    padding-bottom: 2px;
 }
 
 .svg-flip {
@@ -117,7 +116,6 @@ h2 {
     transform: rotate(180deg);
     z-index: -1;
 }
-
 
 .anim-waving img {
     animation-name: waving;
@@ -154,11 +152,9 @@ h2 {
     0% {
         transform: translate(0, 0px);
     }
-
     50% {
         transform: translate(0, -0.5rem);
     }
-
     100% {
         transform: translate(0, 0px);
     }


### PR DESCRIPTION
Change the underline of the titles from text-decoration to border. It looks better in my opinion. Let me know what you think.
Before:
![image](https://user-images.githubusercontent.com/26633429/51431066-8fe81080-1c2c-11e9-8bcf-0fc33bc99660.png)
After:
![image](https://user-images.githubusercontent.com/26633429/51431070-9a0a0f00-1c2c-11e9-8f14-a8750a1e85b3.png)

