### PR TITLE
Fixed 'backen' typo in the metas

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,19 +7,19 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="theme-color" content="#EB6E80">
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-  
+
   <!-- Search Engine -->
-  <meta name="description" content="Dedicated to monitoring the top 5 job demands in the 4 categories: Web, Mobile, Programming Languages, Backen">
+  <meta name="description" content="Dedicated to monitoring the top 5 job demands in the 4 categories: Web, Mobile, Programming Languages, Backend">
   <!-- Schema.org for Google -->
   <meta itemprop="name" content="Full Stack Trends">
-  <meta itemprop="description" content="Dedicated to monitoring the top 5 job demands in the 4 categories: Web, Mobile, Programming Languages, Backen">
+  <meta itemprop="description" content="Dedicated to monitoring the top 5 job demands in the 4 categories: Web, Mobile, Programming Languages, Backend">
   <!-- Twitter -->
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="Full Stack Trends">
-  <meta name="twitter:description" content="Dedicated to monitoring the top 5 job demands in the 4 categories: Web, Mobile, Programming Languages, Backen">
+  <meta name="twitter:description" content="Dedicated to monitoring the top 5 job demands in the 4 categories: Web, Mobile, Programming Languages, Backend">
   <!-- Open Graph general (Facebook, Pinterest & Google+) -->
   <meta name="og:title" content="Full Stack Trends">
-  <meta name="og:description" content="Dedicated to monitoring the top 5 job demands in the 4 categories: Web, Mobile, Programming Languages, Backen">
+  <meta name="og:description" content="Dedicated to monitoring the top 5 job demands in the 4 categories: Web, Mobile, Programming Languages, Backend">
   <meta name="og:url" content="https://www.fullstacktrends.com">
   <meta name="og:site_name" content="Full Stack Trends">
   <meta name="og:type" content="website">
@@ -30,7 +30,7 @@
     crossorigin="anonymous">
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pretty-checkbox@3.0/dist/pretty-checkbox.min.css">
-  
+
   <!--  Font link  -->
   <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
 


### PR DESCRIPTION
The typo described in the issue #149 was also found in the meta tags of the index.html file.
I've corrected them as well.