### PR TITLE
Issue: Title of courses in the Zero To Mastery modal in the footer

### DIFF
--- a/src/components/Modal/Modal.css
+++ b/src/components/Modal/Modal.css
@@ -18,5 +18,8 @@
 
 .modalWindow {
   transition: 0.8s ease-in;
+}
 
+.modalWindow h5 {
+  color: rgb(226, 78, 66);
 }


### PR DESCRIPTION
This push deals with the issue where the titles of the courses in the modal for the Zero To Mastery description found in the footer. The issue was the titles were in white color on a white background. This update provides the title of the courses the same color as the main Zero To Mastery title in the modal so they are visible on the white background.